### PR TITLE
Fix for adding items to the black- and whitelists

### DIFF
--- a/Util.lua
+++ b/Util.lua
@@ -134,7 +134,7 @@ function Util.getId(itemLinkOrId)
 	if not itemLinkOrId then return end
 	if (tonumber(itemLinkOrId)) then return tonumber(itemLinkOrId) end
 
-	local _, _, _, _, id = string.find(itemLinkOrId, "|?c?f?f?(%x*)|?H?([^:]*):?(%d+):?(%d*):?(%d*):?(%d*):?(%d*):?(%d*):?(%-?%d*):?(%-?%d*):?(%d*):?(%d*)|?h?%[?([^%[%]]*)%]?|?h?|?r?")
+	local id = itemLinkOrId:match("|Hitem:(%d+):")
 
 	return tonumber(id)
 end


### PR DESCRIPTION
I replaced the complicated string.find call in the Util.getId function with a much simpler match call. This should fix https://github.com/Eliote/AutoLooter/issues/6.